### PR TITLE
Fixed the broken link of smooch bot Github url in package.json fixing issue #33.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "hbs": "^4.0.0",
     "jsonwebtoken": "^5.7.0",
     "lodash": "^4.6.1",
-    "smooch-bot": "https://github.com/skhavari/smooch-bot.git",
+    "smooch-bot": "https://github.com/smooch/smooch-bot.git",
     "smooch-core": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- The previous git repo `https://github.com/skhavari/smooch-bot.git` doesn't seem to exist anymore. Updating it to use `https://github.com/smooch/smooch-bot.git`. 
- This will fix the https://github.com/esthercrawford/EstherBot/issues/33 issue that has been reported consistently.